### PR TITLE
Fixed stretched out image

### DIFF
--- a/src/components/blog.tsx
+++ b/src/components/blog.tsx
@@ -13,7 +13,7 @@ const BlogCard: React.FC<Meta> = (props) => {
         <Image
           src={props.previewImg}
           alt={props.title}
-          className="mx-auto aspect-[2/1] h-28 py-4 md:h-36 xl:h-48"
+          className="mx-auto aspect-[2/1] h-28 object-cover py-4 md:h-36 xl:h-48"
           height={400}
           width={800}
         />


### PR DESCRIPTION
A really small fix that I'd like to fix because it is bugging me

Before:

![Screenshot from 2023-01-16 17-57-18](https://user-images.githubusercontent.com/95122845/212721683-edea1db1-e099-40a5-9cf5-aa65a7f7aa17.png)

After:

![Screenshot from 2023-01-16 18-07-07](https://user-images.githubusercontent.com/95122845/212722070-7f2e0fef-2e68-4459-a5f2-b1d5718a5985.png)
